### PR TITLE
Adjust homepage game iframe layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
                 <h2 class="embed-title">Play Fruit Connect 3 Online</h2>
                 <p class="embed-description">Beat the clock as you clear the orchard! Tap matching tiles, create open paths, and chain combos for a perfect harvest.</p>
                 <div class="embed-wrapper">
-                    <iframe src="https://html5.gamedistribution.com/594cdf85dea84167b3f01f9e3cd90851/?gd_sdk_referrer_url=https://www.example.com/games/fruit-connect-3" width="960" height="600" scrolling="none" frameborder="0" allowfullscreen></iframe>
+                    <iframe src="https://html5.gamedistribution.com/2abdcdeac7ef400985b05fcc7265d5b7/?gd_sdk_referrer_url=https://www.example.com/games/fruit-connect-3" width="800" height="600" scrolling="no" frameborder="0" allowfullscreen title="Play Fruit Connect 3"></iframe>
                 </div>
                 <p class="embed-footnote"><i class="fas fa-info-circle"></i> The game loads directly from GameDistribution. Please allow a few seconds for the orchard to appear.</p>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -208,7 +208,6 @@ main {
     .hero { padding: 100px 0 80px; }
     .hero-title { font-size: 2.4rem; }
     .hero-subtitle { font-size: 1.05rem; }
-    .embed-wrapper iframe { min-height: 420px; }
 }
 
 /* 游戏展示区域 */
@@ -251,21 +250,35 @@ main {
 
 .embed-wrapper {
     position: relative;
-    max-width: 960px;
+    width: 100%;
+    max-width: 820px;
     margin: 0 auto;
     background: radial-gradient(circle at top left, rgba(255, 209, 102, 0.25), transparent 70%);
     border-radius: var(--radius-xl);
     overflow: hidden;
     box-shadow: 0 28px 60px rgba(255, 107, 107, 0.18);
     border: 6px solid rgba(255, 255, 255, 0.85);
+    aspect-ratio: 4 / 3;
 }
 
 .embed-wrapper iframe {
     display: block;
     width: 100%;
     height: 100%;
-    min-height: 600px;
     border: 0;
+}
+
+@supports not (aspect-ratio: 4 / 3) {
+    .embed-wrapper {
+        height: 0;
+        padding-top: 75%;
+    }
+
+    .embed-wrapper iframe {
+        position: absolute;
+        inset: 0;
+        height: 100%;
+    }
 }
 
 .embed-footnote {


### PR DESCRIPTION
## Summary
- update the homepage embed to use the new GameDistribution URL and tidy iframe attributes
- resize the embed wrapper to a narrower, responsive 4:3 frame that better matches the page design
- add a CSS fallback for browsers without aspect-ratio support

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d50318ddb883219cdc638a491f40f0