### PR TITLE
Add dedicated games page with new featured embeds

### DIFF
--- a/games.html
+++ b/games.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>热门小游戏合集 | Game Center</title>
+    <meta name="description" content="在 Game Center 体验超级玛丽、3D 魔方、自由车手和高空布偶等热门小游戏，直接在线畅玩。">
+    <link rel="stylesheet" href="styles.css?v=20250918">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-container">
+            <div class="nav-brand">
+                <i class="fas fa-gamepad"></i>
+                <span>Game Center</span>
+            </div>
+            <div class="nav-menu" id="nav-menu">
+                <a href="index.html" class="nav-link">Home</a>
+                <a href="#catalog" class="nav-link active">Games</a>
+                <a href="news.html" class="nav-link">Latest News</a>
+                <a href="index.html#about" class="nav-link">About</a>
+            </div>
+            <div class="nav-toggle" id="nav-toggle">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+        </div>
+    </nav>
+
+    <main>
+        <section id="catalog" class="page-hero games-page-hero">
+            <div class="container">
+                <span class="page-hero-subtitle">New Arrivals</span>
+                <h1 class="page-hero-title">热门小游戏合集</h1>
+                <p class="page-hero-description">一次性探索我们精选的互动小游戏合集，直接在线游玩，无需下载。</p>
+            </div>
+        </section>
+
+        <section class="game-detail-section" id="super-mario">
+            <div class="container game-detail">
+                <div class="game-detail-text">
+                    <span class="game-detail-tag">街机 · 冒险</span>
+                    <h2>超级玛丽</h2>
+                    <p>怀旧又经典的平台跳跃游戏，带你重温像素世界的黄金时代。操控马里奥穿越蘑菇王国，打败库巴并营救公主。</p>
+                </div>
+                <div class="game-detail-embed">
+                    <div class="responsive-iframe">
+                        <iframe src="https://jcw87.github.io/c2-smb1/" title="Super Mario Bros" allowfullscreen loading="lazy"></iframe>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="game-detail-section" id="cube">
+            <div class="container game-detail">
+                <div class="game-detail-text">
+                    <span class="game-detail-tag">益智 · 3D</span>
+                    <h2>3D 魔方</h2>
+                    <p>沉浸式 3D 魔方模拟器，支持多种配色方案，帮助你锻炼空间思维能力。拖动旋转，尝试复原每一面颜色。</p>
+                </div>
+                <div class="game-detail-embed">
+                    <div class="responsive-iframe">
+                        <iframe id="zoo-3dcube" src="https://zoo-js.github.io/3dcube/?red=cat&amp;white=dog&amp;blue=pig&amp;green=sheep&amp;orange=koala&amp;yellow=ant&amp;bg=*ffd8bf" name="3dcube" title="3D Cube Puzzle" scrolling="no" frameborder="0" loading="lazy"></iframe>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="game-detail-section" id="bike">
+            <div class="container game-detail">
+                <div class="game-detail-text">
+                    <span class="game-detail-tag">街机 · 物理</span>
+                    <h2>自由车手</h2>
+                    <p>灵活的物理骑行游戏，在社区设计的赛道上体验惊险刺激的空翻和特技，挑战你的操作极限。</p>
+                </div>
+                <div class="game-detail-embed">
+                    <div class="responsive-iframe">
+                        <iframe src="https://www.freeriderhd.com/game/1004698-carbon?embedded=true" title="Free Rider HD" frameborder="0" scrolling="no" allowfullscreen allow="gamepad *; fullscreen; autoplay" loading="lazy"></iframe>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="game-detail-section" id="mega-fall">
+            <div class="container game-detail">
+                <div class="game-detail-text">
+                    <span class="game-detail-tag">街机 · 休闲</span>
+                    <h2>Mega Fall Ragdoll Simulator</h2>
+                    <p>将布偶角色从高空投掷，观察它穿越各种障碍并获得高分。轻松有趣的放松向小游戏，适合随时来一局。</p>
+                </div>
+                <div class="game-detail-embed">
+                    <div class="responsive-iframe wide">
+                        <iframe src="https://www.crazygames.com/embed/mega-fall-ragdoll-simulator" title="Mega Fall Ragdoll Simulator" allow="fullscreen; gamepad; xr-spatial-tracking; autoplay" allowfullscreen loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h4>Game Center</h4>
+                    <p>Free online game platform</p>
+                </div>
+                <div class="footer-section">
+                    <h4>Browse</h4>
+                    <ul>
+                        <li><a href="index.html#games">All Games</a></li>
+                        <li><a href="#catalog">Game Catalog</a></li>
+                        <li><a href="news.html">Latest News</a></li>
+                        <li><a href="index.html#about">About</a></li>
+                        <li><a href="sitemap.xml">Sitemap</a></li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>Contact</h4>
+                    <p>Questions or feedback? Let us know.</p>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 Game Center. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="script.js?v=20250918"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
             </div>
             <div class="nav-menu" id="nav-menu">
                 <a href="#games" class="nav-link active">Games</a>
+                <a href="games.html#catalog" class="nav-link">Game Catalog</a>
                 <a href="news.html" class="nav-link">Latest News</a>
                 <a href="#about" class="nav-link">About</a>
             </div>
@@ -238,6 +239,7 @@
                     <h4>Browse</h4>
                     <ul>
                         <li><a href="#games">All Games</a></li>
+                        <li><a href="games.html#catalog">Game Catalog</a></li>
                         <li><a href="news.html">Latest News</a></li>
                         <li><a href="#about">About</a></li>
                         <li><a href="sitemap.xml">Sitemap</a></li>

--- a/script.js
+++ b/script.js
@@ -197,11 +197,38 @@ const gamesData = [
         image: "https://via.placeholder.com/300x200/00ff88/000000?text=Pong+Game",
         url: "pong-game.html",
         fallback: false
+    },
+    {
+        id: 23,
+        title: "超级玛丽",
+        description: "重温经典平台跳跃冒险，帮助马里奥营救公主",
+        category: "arcade",
+        image: "https://via.placeholder.com/300x200/2563eb/ffffff?text=Super+Mario",
+        url: "https://jcw87.github.io/c2-smb1/",
+        fallback: false
+    },
+    {
+        id: 24,
+        title: "3D 魔方",
+        description: "用 3D 魔方练习空间思维，尝试快速复原",
+        category: "puzzle",
+        image: "https://via.placeholder.com/300x200/0ea5e9/ffffff?text=3D+Cube",
+        url: "https://zoo-js.github.io/3dcube/?red=cat&white=dog&blue=pig&green=sheep&orange=koala&yellow=ant&bg=*ffd8bf",
+        fallback: false
+    },
+    {
+        id: 25,
+        title: "自由车手",
+        description: "在炫酷赛道上骑行，挑战物理骑行极限",
+        category: "arcade",
+        image: "https://via.placeholder.com/300x200/f97316/ffffff?text=Bike+Rider",
+        url: "https://www.freeriderhd.com/game/1004698-carbon?embedded=true",
+        fallback: false
     }
 ];
 
 // 生成更多游戏数据以达到100个游戏
-for (let i = 23; i <= 100; i++) {
+for (let i = gamesData.length + 1; i <= 100; i++) {
     const categories = ['puzzle', 'strategy', 'arcade', 'adventure'];
     const category = categories[Math.floor(Math.random() * categories.length)];
     
@@ -390,6 +417,10 @@ function initializeNavigation() {
 
 // 游戏功能
 function initializeGames() {
+    if (!gamesGrid) {
+        return;
+    }
+
     if (!loadMoreBtn) {
         displayedGames = gamesData.length;
     }
@@ -400,6 +431,9 @@ function initializeGames() {
 }
 
 function renderGames() {
+    if (!gamesGrid) {
+        return;
+    }
     let filteredGames = gamesData;
     
     // 按类别筛选
@@ -579,6 +613,10 @@ function initializeLazyLoading() {
 
 // 模态框功能
 function initializeModal() {
+    if (!gameModal || !modalClose || !gameFrame || !modalTitle) {
+        return;
+    }
+
     modalClose.addEventListener('click', closeModal);
     
     gameModal.addEventListener('click', function(e) {
@@ -586,7 +624,7 @@ function initializeModal() {
             closeModal();
         }
     });
-    
+
     // ESC键关闭模态框
     document.addEventListener('keydown', function(e) {
         if (e.key === 'Escape' && gameModal.classList.contains('active')) {
@@ -596,6 +634,11 @@ function initializeModal() {
 }
 
 function openGame(url, title) {
+    if (!gameModal || !gameFrame || !modalTitle) {
+        window.open(url, '_blank');
+        return;
+    }
+
     modalTitle.textContent = title;
     gameFrame.src = url;
     gameModal.classList.add('active');
@@ -603,6 +646,10 @@ function openGame(url, title) {
 }
 
 function closeModal() {
+    if (!gameModal || !gameFrame) {
+        return;
+    }
+
     gameModal.classList.remove('active');
     gameFrame.src = '';
     document.body.style.overflow = 'auto';

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -11,6 +11,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://hotspotgame.net/games.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://hotspotgame.net/pong-game.html</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>

--- a/styles.css
+++ b/styles.css
@@ -1212,3 +1212,140 @@ main {
     overflow: hidden;
 }
 
+/* 游戏合集页面 */
+.page-hero {
+    padding: 140px 0 80px;
+    background: radial-gradient(circle at top left, rgba(17, 138, 178, 0.18), transparent 55%), var(--gradient-secondary);
+    color: #fff;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+}
+
+.page-hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at bottom right, rgba(255, 255, 255, 0.25), transparent 55%);
+    pointer-events: none;
+}
+
+.page-hero .container {
+    position: relative;
+    z-index: 1;
+}
+
+.games-page-hero .page-hero-subtitle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 16px;
+    background: rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.page-hero-title {
+    font-size: 2.8rem;
+    margin: 18px 0 12px;
+    font-weight: 800;
+}
+
+.page-hero-description {
+    max-width: 660px;
+    margin: 0 auto;
+    font-size: 1.1rem;
+    opacity: 0.92;
+}
+
+.game-detail-section {
+    padding: 80px 0;
+}
+
+.game-detail {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 48px;
+    align-items: center;
+}
+
+.game-detail:nth-child(even) .game-detail-text {
+    order: 2;
+}
+
+.game-detail-tag {
+    display: inline-block;
+    padding: 6px 16px;
+    background: rgba(17, 138, 178, 0.12);
+    color: var(--info-color);
+    border-radius: 999px;
+    font-weight: 600;
+    margin-bottom: 18px;
+}
+
+.game-detail h2 {
+    font-size: 2rem;
+    margin-bottom: 16px;
+}
+
+.game-detail p {
+    font-size: 1.05rem;
+    color: var(--gray-color);
+}
+
+.game-detail-embed {
+    width: 100%;
+}
+
+.responsive-iframe {
+    position: relative;
+    width: 100%;
+    padding-bottom: 56.25%;
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: 0 25px 60px rgba(17, 138, 178, 0.18);
+    background: #000;
+}
+
+.responsive-iframe.wide {
+    padding-bottom: 56.25%;
+}
+
+.responsive-iframe iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
+@media (max-width: 992px) {
+    .game-detail {
+        grid-template-columns: 1fr;
+    }
+
+    .game-detail:nth-child(even) .game-detail-text {
+        order: 0;
+    }
+
+    .page-hero-title {
+        font-size: 2.2rem;
+    }
+}
+
+@media (max-width: 600px) {
+    .game-detail-section {
+        padding: 60px 0;
+    }
+
+    .page-hero {
+        padding: 120px 0 70px;
+    }
+
+    .page-hero-description {
+        font-size: 1rem;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a standalone games catalog page with featured embeds for Super Mario, 3D Cube, Free Rider, and Mega Fall
- link the home navigation and footer to the new catalog and list the new games in the homepage data set
- guard modal logic for pages without the grid, refresh styles for the catalog layout, and register the page in the sitemap

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68df5325e47c8321b38e877199af4c56