### PR TITLE
Remove landing hero and surface gameplay immediately

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,14 +50,6 @@
     </nav>
 
     <main class="landing-main">
-        <section class="hub-intro">
-            <div class="container">
-                <div class="intro-chip">Featured Puzzle</div>
-                <h1 class="intro-title">Fruit Connect 3 launches instantly.</h1>
-                <p class="intro-subtitle">Match vibrant fruit tiles and clear the board right from the landing page—no extra clicks required.</p>
-            </div>
-        </section>
-
         <div class="hub-grid container">
             <section class="game-showcase">
                 <header class="game-showcase-header">

--- a/styles.css
+++ b/styles.css
@@ -1454,38 +1454,8 @@ main {
     background: rgba(255, 107, 107, 0.1);
 }
 
-/* Intro section */
-.hub-intro {
-    padding: 140px 0 40px;
-    text-align: center;
-}
-
-.intro-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 16px;
-    background: rgba(255, 107, 107, 0.12);
-    color: var(--primary-color);
-    font-weight: 600;
-    border-radius: 999px;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-size: 0.75rem;
-}
-
-.intro-title {
-    font-size: clamp(2rem, 3vw, 3rem);
-    margin: 18px 0 12px;
-    font-weight: 800;
-    color: var(--dark-color);
-}
-
-.intro-subtitle {
-    max-width: 640px;
-    margin: 0 auto;
-    color: rgba(31, 41, 55, 0.72);
-    font-size: 1rem;
+.landing-main {
+    padding: 120px 0 80px;
 }
 
 /* Grid layout */
@@ -1939,8 +1909,8 @@ main {
 }
 
 @media (max-width: 576px) {
-    .hub-intro {
-        padding-top: 120px;
+    .landing-main {
+        padding-top: 100px;
     }
 
     .stage-player {


### PR DESCRIPTION
## Summary
- remove the hero banner content so the landing page opens directly on the playable embed and supporting details
- add top padding on the landing layout to keep the fixed navigation from covering the game, with a mobile tweak

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e3d9e97e14832185ae54e130227b4b